### PR TITLE
Make it work with pg 1.0.0

### DIFF
--- a/lib/posgra/client.rb
+++ b/lib/posgra/client.rb
@@ -342,6 +342,6 @@ class Posgra::Client
       end
     end
 
-    PGconn.connect(connect_options)
+    PG::Connection.connect(connect_options)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -130,7 +130,7 @@ module SpecHelper
 
   def pg(dbname = DBNAME)
     begin
-      conn = PGconn.connect(
+      conn = PG::Connection.connect(
         host: DBHOST,
         port: DBPORT,
         user: DBUSER,


### PR DESCRIPTION
`PGconn` has been renamed to `PG::Connection` in [v0.13.0](https://bitbucket.org/ged/ruby-pg/src/d8734ec382c9af8bd8bbe062d3668c93dd4ecf5b/History.rdoc#History.rdoc-322) and removed in [v1.0.0](https://bitbucket.org/ged/ruby-pg/src/d8734ec382c9af8bd8bbe062d3668c93dd4ecf5b/History.rdoc#History.rdoc-10).