### PR TITLE
Support role attributes

### DIFF
--- a/lib/posgra/dsl/converter.rb
+++ b/lib/posgra/dsl/converter.rb
@@ -18,7 +18,8 @@ class Posgra::DSL::Converter
 
   def convert_roles
     users_by_group = @exported[:users_by_group] || {}
-    users = @exported.fetch(:users, []) - users_by_group.values.flatten
+    users_in_group = users_by_group.values.flatten
+    users = @exported.fetch(:users, {}).reject {|u, o| o.empty? && users_in_group.include?(u) }
 
     [
       output_users(users),
@@ -39,9 +40,22 @@ class Posgra::DSL::Converter
   private
 
   def output_users(users)
-    users.sort.map {|user|
-      "user #{user.inspect}"
+    users.sort.map {|user, options|
+      output_user(user, options)
     }.join("\n") + "\n"
+  end
+
+  def output_user(user, options)
+    "user #{user.inspect}#{output_user_options(options)}"
+  end
+
+  def output_user_options(options)
+    if options.empty?
+      ''
+    else
+      options = strip_hash_brace(options.inspect)
+      ", #{options}"
+    end
   end
 
   def output_groups(users_by_group)
@@ -183,4 +197,7 @@ end
     EOS
   end
 
+  def strip_hash_brace(hash_str)
+    hash_str.sub(/\A\{/, '').sub(/\}\z/, '')
+  end
 end

--- a/lib/posgra/dsl/roles.rb
+++ b/lib/posgra/dsl/roles.rb
@@ -10,8 +10,6 @@ class Posgra::DSL::Roles
   end
 
   def result
-    @result[:users].uniq!
-
     group_users = @result[:users_by_group].flat_map do |group, users|
       if users.empty?
         [group, nil]
@@ -38,7 +36,7 @@ class Posgra::DSL::Roles
     @path = path
     @options = options
     @result = {
-      :users => [],
+      :users => {},
       :users_by_group => {},
     }
 
@@ -69,11 +67,11 @@ class Posgra::DSL::Roles
     end
   end
 
-  def user(name, &block)
+  def user(name, options = {}, &block)
     name = name.to_s
 
     if matched?(name, @options[:include_role], @options[:exclude_role])
-      @result[:users] << name
+      @result[:users][name] = options
     end
   end
 

--- a/lib/posgra/exporter.rb
+++ b/lib/posgra/exporter.rb
@@ -18,7 +18,7 @@ class Posgra::Exporter
 
   def export_roles
     {
-      :users => @driver.describe_users.keys,
+      :users => @driver.describe_users,
       :users_by_group => @driver.describe_groups,
     }
   end

--- a/spec/posgra_roles_create_spec.rb
+++ b/spec/posgra_roles_create_spec.rb
@@ -31,6 +31,24 @@ describe 'roles (create)' do
     end
   end
 
+  context 'when create user with role attributes' do
+    it do
+      expect(
+        apply_roles do
+          <<-RUBY
+            user "alice", :superuser => true
+            user "bob", :connection_limit => 100, :createdb => true, :createrole => true, :inherit => true, :replication => true, :valid_until => "2018-01-01"
+          RUBY
+        end
+      ).to be_truthy
+
+      is_expected.to match_fuzzy <<-RUBY
+        user "alice", :superuser => true
+        user "bob", :connection_limit => 100, :createdb => true, :createrole => true, :replication => true, :valid_until => "2018-01-01 00:00:00+00"
+      RUBY
+    end
+  end
+
   context 'when create group only' do
     it do
       expect(

--- a/spec/posgra_roles_update_spec.rb
+++ b/spec/posgra_roles_update_spec.rb
@@ -6,7 +6,7 @@ describe 'roles (update)' do
   before do
     apply_roles do
       <<-RUBY
-        user "alice"
+        user "alice", :connection_limit => 100, :superuser => true, :valid_until => "2018-01-01"
 
         group "staff" do
           user "bob"
@@ -42,14 +42,14 @@ describe 'roles (update)' do
       expect(
         apply_roles do
           <<-RUBY
-            user "alice"
+            user "alice", :connection_limit => 100, :superuser => true, :valid_until => "2018-01-01"
             user "bob"
           RUBY
         end
       ).to be_truthy
 
       is_expected.to match_fuzzy <<-RUBY
-        user "alice"
+        user "alice", :connection_limit => 100, :superuser => true, :valid_until => "2018-01-01 00:00:00+00"
         user "bob"
       RUBY
     end
@@ -60,7 +60,7 @@ describe 'roles (update)' do
       expect(
         apply_roles do
           <<-RUBY
-            user "alice"
+            user "alice", :connection_limit => 100, :superuser => true, :valid_until => "2018-01-01"
             user "bob"
             user "staff"
           RUBY
@@ -68,7 +68,7 @@ describe 'roles (update)' do
       ).to be_truthy
 
       is_expected.to match_fuzzy <<-RUBY
-        user "alice"
+        user "alice", :connection_limit => 100, :superuser => true, :valid_until => "2018-01-01 00:00:00+00"
         user "bob"
         user "staff"
       RUBY
@@ -93,6 +93,30 @@ describe 'roles (update)' do
         group "alice" do
           # no users
         end
+
+        group "staff" do
+          user "bob"
+        end
+      RUBY
+    end
+  end
+
+  context 'when change role attributes' do
+    it do
+      expect(
+        apply_roles do
+          <<-RUBY
+            user "alice", :createdb => true
+
+            group "staff" do
+              user "bob"
+            end
+          RUBY
+        end
+      ).to be_truthy
+
+      is_expected.to match_fuzzy <<-RUBY
+        user "alice", :createdb => true
 
         group "staff" do
           user "bob"


### PR DESCRIPTION
I would like to add support for creating a user with role attributes.

https://www.postgresql.org/docs/10/static/sql-createuser.html

```
user "alice", :superuser => true
user "bob", :connection_limit => 100, :createdb => true, :createrole => true, :inherit => true, :replication => true, :valid_until => "2018-01-01" 
```

To keep DSL and code as simple as possible, this patch doesn't support specifying role attributes with `user` inside `group` block. I would like to know what you think about it.